### PR TITLE
feat(calendar): add lunch break slots to day and week views

### DIFF
--- a/src/features/calendar/components/DayView.tsx
+++ b/src/features/calendar/components/DayView.tsx
@@ -2,6 +2,8 @@ import { useMemo } from "react";
 import { generateTimeSlots } from "../utils";
 import { mapDayTalks } from "../mapper";
 import { TalkItem } from "./TalkItem";
+import { LunchBreakSlot } from "./LunchBreakSlot";
+import { cn } from "@/lib/utils";
 import type { Talk } from "../types";
 
 interface DayViewProps {
@@ -41,12 +43,15 @@ export function DayView({ currentDate, talks }: DayViewProps) {
       <div className="flex flex-1 overflow-auto">
         {/* Time slots */}
         <div className="border-r w-16 shrink-0">
-          {timeSlots.map((time, idx) => (
+          {timeSlots.map((slot, idx) => (
             <div
               key={idx}
-              className="border-b h-30 p-1 text-xs text-right text-muted-foreground pr-2"
+              className={cn(
+                "border-b h-30 p-1 text-xs text-right pr-2",
+                !slot.isBreakTime && "text-muted-foreground",
+              )}
             >
-              {time}
+              {slot.time}
             </div>
           ))}
         </div>
@@ -54,9 +59,13 @@ export function DayView({ currentDate, talks }: DayViewProps) {
         {/* Day content */}
         <div className="flex-1 relative">
           {/* Time slots background */}
-          {timeSlots.map((_, idx) => (
-            <div key={idx} className="border-b h-30"></div>
-          ))}
+          {timeSlots.map((slot, idx) =>
+            slot.isBreakTime ? (
+              <LunchBreakSlot key={idx} />
+            ) : (
+              <div key={idx} className="border-b h-30"></div>
+            ),
+          )}
 
           {/* Talks */}
           <div className="absolute inset-0">

--- a/src/features/calendar/components/LunchBreakSlot.tsx
+++ b/src/features/calendar/components/LunchBreakSlot.tsx
@@ -1,0 +1,30 @@
+import { LUNCH_BREAK_LABEL } from "../utils";
+import { cn } from "@/lib/utils";
+
+interface LunchBreakSlotProps {
+  showLabel?: boolean;
+  className?: string;
+}
+
+export function LunchBreakSlot({
+  showLabel = true,
+  className,
+}: LunchBreakSlotProps) {
+  return (
+    <div
+      className={cn("relative border-b h-30 w-full", className)}
+      style={{
+        backgroundImage:
+          "repeating-linear-gradient(45deg, transparent, transparent 5px, rgba(0,0,0,0.05) 5px, rgba(0,0,0,0.05) 10px)",
+      }}
+    >
+      {showLabel && (
+        <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+          <span className="text-xs font-medium text-muted-foreground px-2 py-1 bg-background/80 rounded shadow-sm">
+            {LUNCH_BREAK_LABEL}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/calendar/components/WeekView.tsx
+++ b/src/features/calendar/components/WeekView.tsx
@@ -2,6 +2,8 @@ import { useMemo } from "react";
 import { getWeekDays, formatDay, generateTimeSlots } from "../utils";
 import { mapWeekTalks } from "../mapper";
 import { TalkItem } from "./TalkItem";
+import { LunchBreakSlot } from "./LunchBreakSlot";
+import { cn } from "@/lib/utils";
 import type { Talk } from "../types";
 
 interface WeekViewProps {
@@ -42,12 +44,15 @@ export function WeekView({ currentDate, talks }: WeekViewProps) {
       <div className="flex flex-1 overflow-auto">
         {/* Time slots */}
         <div className="border-r w-16 shrink-0">
-          {timeSlots.map((time, idx) => (
+          {timeSlots.map((slot, idx) => (
             <div
               key={idx}
-              className="border-b h-30 p-1 text-xs text-right text-muted-foreground pr-2"
+              className={cn(
+                "border-b h-30 p-1 text-xs text-right pr-2",
+                !slot.isBreakTime && "text-muted-foreground",
+              )}
             >
-              {time}
+              {slot.time}
             </div>
           ))}
         </div>
@@ -56,13 +61,19 @@ export function WeekView({ currentDate, talks }: WeekViewProps) {
         <div className="grid grid-cols-7 flex-1">
           {weekDays.map((_, dayIdx) => {
             const dayTalks = mappedWeekTalks[dayIdx] || [];
+            // N'afficher le label que sur la première colonne pour éviter l'encombrement visuel
+            const isFirstColumn = dayIdx === 0;
 
             return (
               <div key={dayIdx} className="border-r relative w-full">
                 {/* Time slots background */}
-                {timeSlots.map((_, idx) => (
-                  <div key={idx} className="border-b h-30"></div>
-                ))}
+                {timeSlots.map((slot, idx) =>
+                  slot.isBreakTime ? (
+                    <LunchBreakSlot key={idx} showLabel={isFirstColumn} />
+                  ) : (
+                    <div key={idx} className="border-b h-30"></div>
+                  ),
+                )}
 
                 {/* Talks */}
                 <div className="absolute inset-0">

--- a/src/features/calendar/types.ts
+++ b/src/features/calendar/types.ts
@@ -23,3 +23,8 @@ export interface PositionedTalk extends Talk {
 
 export type CalendarViewType = "day" | "week";
 export type Room = "Room A" | "Room B" | "Room C" | "Room D" | "Room E";
+
+export interface TimeSlot {
+  time: string;
+  isBreakTime?: boolean;
+}

--- a/src/features/calendar/utils.ts
+++ b/src/features/calendar/utils.ts
@@ -7,6 +7,10 @@ import {
 } from "date-fns";
 import type { Talk } from "../types";
 
+export const LUNCH_BREAK_START_HOUR = 12;
+export const LUNCH_BREAK_END_HOUR = 13;
+export const LUNCH_BREAK_LABEL = "Lunch break";
+
 // Format date to display in header
 export const formatDate = (date: Date): string => {
   return format(date, "MMMM d, yyyy");
@@ -26,10 +30,13 @@ export const formatDay = (date: Date): string => {
 };
 
 // Generate time slots for the calendar - Use smaller increments for finer granularity
-export const generateTimeSlots = (): string[] => {
-  const slots: string[] = [];
+export const generateTimeSlots = (): TimeSlot[] => {
+  const slots: TimeSlot[] = [];
   for (let i = 9; i < 19; i++) {
-    slots.push(`${i}:00`);
+    slots.push({
+      time: `${i}:00`,
+      isBreakTime: i >= LUNCH_BREAK_START_HOUR && i < LUNCH_BREAK_END_HOUR,
+    });
   }
   return slots;
 };


### PR DESCRIPTION
## 📝 Description
Implement lunch break visualization in the calendar with a cross-hatched pattern to clearly indicate unavailable time slots (12:00-13:00).

Related task : [BAB-65](https://gofast-cdn.atlassian.net/browse/BAB-65)

## 📸 Screenshots
<img width="651" alt="image" src="https://github.com/user-attachments/assets/af6ead3d-135d-4a9e-b5ac-c97d8c280bcd" />


## ✅ Checklist
- [x] Code follows project standards (lint, format)
- [x] Responsive design verified on different screen sizes
- [x] Performance optimization verified (if applicable)
- [x] Documentation updated (if applicable)

[BAB-65]: https://gofast-cdn.atlassian.net/browse/BAB-65?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ