### PR TITLE
chore(workflow): restrict PR trigger types to opened only

### DIFF
--- a/.github/workflows/pr-jira-adapter.yml
+++ b/.github/workflows/pr-jira-adapter.yml
@@ -2,9 +2,8 @@ name: Update PR Description with JIRA ID
 
 on:
   pull_request:
-    types: [opened, edited]
+    types: [opened]
 
-# Add this permissions block
 permissions:
   pull-requests: write
   contents: read


### PR DESCRIPTION
Related task : [BAB-79](https://gofast-cdn.atlassian.net/browse/BAB-79)

[BAB-79]: https://gofast-cdn.atlassian.net/browse/BAB-79?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ