### PR TITLE
feat(speaker): add SpeakerHeader component and integrate into Speaker Layout

### DIFF
--- a/src/features/speaker/components/SpeakerHeader.tsx
+++ b/src/features/speaker/components/SpeakerHeader.tsx
@@ -1,0 +1,58 @@
+import { SidebarTrigger } from "@/components/ui/sidebar";
+import { useLocation } from "react-router-dom";
+import { SPEAKER_NAV_ITEMS } from "../constants/navigation";
+import type { MenuItem } from "@/types/menuItem";
+
+export function SpeakerHeader() {
+  const location = useLocation();
+  const currentPath = location.pathname.endsWith("/")
+    ? location.pathname.slice(0, -1)
+    : location.pathname;
+
+  // Find the current page title from navigation items recursively
+  const findActivePage = (items: MenuItem[]): string => {
+    // First check for exact match
+    const exactMatch = items.find((item) => item.url === currentPath);
+    if (exactMatch) return exactMatch.title;
+
+    // Check for parent routes
+    const parentMatch = items.find((item) =>
+      currentPath.startsWith(`${item.url}/`),
+    );
+    if (parentMatch) {
+      // If it has submenu, look there
+      if (parentMatch.submenu) {
+        const submenuMatch = parentMatch.submenu.find(
+          (subItem) =>
+            subItem.url === currentPath ||
+            currentPath.startsWith(`${subItem.url}/`),
+        );
+        if (submenuMatch) return submenuMatch.title;
+      }
+      // Otherwise use parent title
+      return parentMatch.title;
+    }
+
+    // Default case for /speaker
+    if (currentPath === "/speaker" || currentPath === "/speaker/") {
+      return "Dashboard";
+    }
+
+    return "Speaker";
+  };
+
+  const pageTitle = findActivePage(SPEAKER_NAV_ITEMS);
+
+  return (
+    <div className="flex h-16 items-center justify-between border-b border-border px-4 lg:px-6">
+      <div className="flex items-center gap-2">
+        <SidebarTrigger />
+        <h1 className="text-lg font-semibold">{pageTitle}</h1>
+      </div>
+
+      <div className="flex items-center gap-2">
+        {/* You can add additional header actions here */}
+      </div>
+    </div>
+  );
+}

--- a/src/features/speaker/components/SpeakerLayout.tsx
+++ b/src/features/speaker/components/SpeakerLayout.tsx
@@ -1,5 +1,6 @@
-import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
+import { SidebarProvider } from "@/components/ui/sidebar";
 import { SpeakerSidebar } from "./SpeakerSidebar";
+import { SpeakerHeader } from "./SpeakerHeader";
 
 export default function SpeakerLayout({
   children,
@@ -9,10 +10,10 @@ export default function SpeakerLayout({
   return (
     <SidebarProvider>
       <SpeakerSidebar />
-      <main>
-        <SidebarTrigger />
-        {children}
-      </main>
+      <div className="flex min-h-screen w-full flex-col">
+        <SpeakerHeader />
+        <main className="flex-1 p-4 md:p-6">{children}</main>
+      </div>
     </SidebarProvider>
   );
 }


### PR DESCRIPTION
## 📝 Description
Integrate speaker header on speaker layout

Related task : [BAB-81](https://gofast-cdn.atlassian.net/browse/BAB-81)

## 📸 Screenshots
<img width="1428" alt="image" src="https://github.com/user-attachments/assets/28490e6e-faaf-4e92-a744-43b850f08977" />

## ✅ Checklist
- [x] Code follows project standards (lint, format)
- [x] Responsive design verified on different screen sizes
- [x] Performance optimization verified (if applicable)
- [x] Documentation updated (if applicable)

[BAB-81]: https://gofast-cdn.atlassian.net/browse/BAB-81?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ