### PR TITLE
feat(organizer-dashboard): add reject talk functionality with modal

### DIFF
--- a/src/features/organizer/dashboard/components/OrganizerDashboard.tsx
+++ b/src/features/organizer/dashboard/components/OrganizerDashboard.tsx
@@ -2,30 +2,37 @@ import { useState } from "react";
 import { Card } from "@/components/ui/card";
 import { CalendarView } from "@/features/calendar/components/CalendarView";
 import PlanificationModal from "./PlanificationModal";
+import RejectTalkModal from "./RejectTalkModal";
 import PendingTalkList from "./PendingTalkList";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useGetPendingTalks } from "@/features/talks/hooks/queries/useGetPendingTalks";
 import type { Talk } from "@/features/talks/types";
 
 const OrganizerDashboard = () => {
-  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isPlanModalOpen, setIsPlanModalOpen] = useState(false);
+  const [isRejectModalOpen, setIsRejectModalOpen] = useState(false);
   const [selectedTalk, setSelectedTalk] = useState<Talk | null>(null);
 
   const { data: pendingTalks, isLoading, error } = useGetPendingTalks();
 
-  const handleOpenModal = (talk: Talk) => {
+  const handleOpenPlanModal = (talk: Talk) => {
     setSelectedTalk(talk);
-    setIsModalOpen(true);
+    setIsPlanModalOpen(true);
   };
 
-  const handleCloseModal = () => {
-    setIsModalOpen(false);
+  const handleOpenRejectModal = (talk: Talk) => {
+    setSelectedTalk(talk);
+    setIsRejectModalOpen(true);
+  };
+
+  const handleClosePlanModal = () => {
+    setIsPlanModalOpen(false);
     setSelectedTalk(null);
   };
 
-  const handleRejectTalk = (talkId: string) => {
-    console.log("Rejecting talk with ID:", talkId);
-    // API call would go here
+  const handleCloseRejectModal = () => {
+    setIsRejectModalOpen(false);
+    setSelectedTalk(null);
   };
 
   return (
@@ -49,8 +56,8 @@ const OrganizerDashboard = () => {
           ) : (
             <PendingTalkList
               talks={pendingTalks || []}
-              onAccept={handleOpenModal}
-              onReject={handleRejectTalk}
+              onAccept={handleOpenPlanModal}
+              onReject={handleOpenRejectModal}
               className="flex-1 flex flex-col max-h-full"
             />
           )}
@@ -59,8 +66,14 @@ const OrganizerDashboard = () => {
 
       <PlanificationModal
         talk={selectedTalk}
-        isOpen={isModalOpen}
-        onClose={handleCloseModal}
+        isOpen={isPlanModalOpen}
+        onClose={handleClosePlanModal}
+      />
+
+      <RejectTalkModal
+        talk={selectedTalk}
+        isOpen={isRejectModalOpen}
+        onClose={handleCloseRejectModal}
       />
     </div>
   );

--- a/src/features/organizer/dashboard/components/PendingTalkList.tsx
+++ b/src/features/organizer/dashboard/components/PendingTalkList.tsx
@@ -6,7 +6,7 @@ import { Check, X } from "lucide-react";
 interface PendingTalkListProps {
   talks: Talk[];
   onAccept: (talk: Talk) => void;
-  onReject: (talkId: string) => void;
+  onReject: (talk: Talk) => void;
   className?: string;
 }
 
@@ -55,6 +55,7 @@ const PendingTalkList = ({
                     </span>
                   </div>
                 </div>
+
                 <div className="flex gap-2 mt-2">
                   <Button
                     size="sm"
@@ -68,7 +69,7 @@ const PendingTalkList = ({
                     size="sm"
                     variant="outline"
                     className="flex-1 bg-red-50 hover:bg-red-100 text-red-700 border-red-200"
-                    onClick={() => onReject(talk.id)}
+                    onClick={() => onReject(talk)}
                   >
                     <X size={16} className="mr-1" /> Reject
                   </Button>

--- a/src/features/organizer/dashboard/components/RejectTalkModal.tsx
+++ b/src/features/organizer/dashboard/components/RejectTalkModal.tsx
@@ -1,0 +1,159 @@
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { X, AlertOctagon } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import type { Talk } from "@/features/talks/types";
+import { useRejectTalk } from "@/features/talks/hooks/mutations/useRejectedTalk";
+import {
+  rejectTalkSchema,
+  type RejectTalkFormValues,
+} from "@/features/talks/schemas/rejectTalkSchema";
+
+interface RejectTalkModalProps {
+  talk: Talk | null;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const RejectTalkModal = ({ talk, isOpen, onClose }: RejectTalkModalProps) => {
+  const form = useForm<RejectTalkFormValues>({
+    resolver: zodResolver(rejectTalkSchema),
+    defaultValues: {
+      message: "",
+    },
+  });
+
+  const rejectTalkMutation = useRejectTalk();
+
+  const handleReject = (values: RejectTalkFormValues) => {
+    if (!talk) return;
+
+    rejectTalkMutation.mutate(
+      {
+        talkId: parseInt(talk.id),
+        message: values.message,
+      },
+      {
+        onSuccess: () => {
+          form.reset();
+          onClose();
+        },
+      },
+    );
+  };
+
+  const onCloseModal = () => {
+    form.reset();
+    onClose();
+  };
+
+  const isPending = rejectTalkMutation.isPending;
+
+  return (
+    <Dialog
+      open={isOpen && !!talk}
+      onOpenChange={(open) => !open && onCloseModal()}
+    >
+      <DialogContent className="sm:max-w-[500px]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-red-600">
+            <AlertOctagon className="h-5 w-5" />
+            Reject Talk
+          </DialogTitle>
+          <DialogDescription>
+            Please provide feedback for the speaker about why this talk was
+            rejected.
+          </DialogDescription>
+        </DialogHeader>
+
+        {talk && (
+          <Form {...form}>
+            <form
+              onSubmit={form.handleSubmit(handleReject)}
+              className="space-y-4"
+            >
+              <div className="space-y-2">
+                <h3 className="font-medium">{talk.title}</h3>
+                <div className="text-sm text-muted-foreground">
+                  <span>by {talk.speaker}</span>
+                  <div className="flex flex-wrap gap-2 mt-1">
+                    <Badge variant="outline">{talk.durationDisplay}</Badge>
+                    <Badge className="bg-blue-100 text-blue-800 hover:bg-blue-200">
+                      {talk.level}
+                    </Badge>
+                    <Badge className="bg-purple-100 text-purple-800 hover:bg-purple-200">
+                      {talk.type}
+                    </Badge>
+                  </div>
+                </div>
+              </div>
+
+              <FormField
+                control={form.control}
+                name="message"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Feedback</FormLabel>
+                    <FormControl>
+                      <Textarea
+                        placeholder="Please provide constructive feedback for the speaker..."
+                        className="min-h-[120px]"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <DialogFooter>
+                <Button
+                  variant="outline"
+                  onClick={onCloseModal}
+                  disabled={isPending}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  type="submit"
+                  variant="destructive"
+                  disabled={isPending || !form.formState.isValid}
+                  className="gap-1"
+                >
+                  {isPending ? (
+                    <>Processing...</>
+                  ) : (
+                    <>
+                      <X className="h-4 w-4" />
+                      Reject Talk
+                    </>
+                  )}
+                </Button>
+              </DialogFooter>
+            </form>
+          </Form>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default RejectTalkModal;

--- a/src/features/talks/hooks/mutations/useRejectedTalk.ts
+++ b/src/features/talks/hooks/mutations/useRejectedTalk.ts
@@ -1,0 +1,45 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { httpClient } from "@/lib/api/http-client";
+import { toast } from "sonner";
+import { pendingTalksKeys } from "../queries/useGetPendingTalks";
+
+interface RejectTalkResponse {
+  id: number;
+  message: string;
+  updatedAt: string;
+}
+
+export const useRejectTalk = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      talkId,
+      message,
+    }: {
+      talkId: number;
+      message: string;
+    }) => {
+      return await httpClient.put<RejectTalkResponse>(
+        `/organizer/talks/${talkId}/refused`,
+        { message },
+      );
+    },
+
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: pendingTalksKeys.lists() });
+
+      toast.success("Talk rejected", {
+        description:
+          "The talk has been rejected. Speaker will be notified with your feedback.",
+      });
+    },
+
+    onError: (error) => {
+      toast.error("Failed to reject talk", {
+        description:
+          error instanceof Error ? error.message : "Please try again later",
+      });
+    },
+  });
+};

--- a/src/features/talks/schemas/rejectTalkSchema.ts
+++ b/src/features/talks/schemas/rejectTalkSchema.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const rejectTalkSchema = z.object({
+  message: z
+    .string()
+    .min(10, "Feedback must contain at least 10 characters")
+    .max(500, "Feedback must not exceed 500 characters"),
+});
+
+export type RejectTalkFormValues = z.infer<typeof rejectTalkSchema>;


### PR DESCRIPTION
## 📝 Description
Add reject talk functionality with modal and validation

Related task : [BAB-101](https://gofast-cdn.atlassian.net/browse/BAB-101)

## 📸 Screenshots
<img width="1155" alt="image" src="https://github.com/user-attachments/assets/e8327e6b-8a17-42a0-b3a2-32fb74b387e2" />


## ✅ Checklist
- [x] Code follows project standards (lint, format)
- [x] Responsive design verified on different screen sizes
- [x] Performance optimization verified (if applicable)
- [x] Documentation updated (if applicable)

[BAB-101]: https://gofast-cdn.atlassian.net/browse/BAB-101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ